### PR TITLE
Use optional parameter for options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ export type Options = {
 
 let config: Options
 
-export default function (input: Element, options: Partial<Options>) {
+export default function (input: Element, options?: Partial<Options>) {
   if (input.nodeType !== Node.ELEMENT_NODE) {
     throw new Error(`Can't generate CSS selector for non-element node type.`)
   }


### PR DESCRIPTION
Thanks to #9 being merged and version 1.0.2 published, I can now use finder in my TS code.

In my project I'm using it like in the example, without passing in options:
`finder(myElement)`

Using it like this I get: `semantic error TS2554 Expected 2 arguments, but got 1.`

This PR allows usage without passing in options when using type information.
