### PR TITLE
Infer the document to query against from `config.root`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ enum Limit {
 
 export type Options = {
   root: Element
+  document: Document,
   className: (name: string) => boolean
   tagName: (name: string) => boolean
   seedMinLength: number
@@ -36,6 +37,7 @@ export default function (input: Element, options?: Partial<Options>) {
 
   const defaults: Options = {
     root: document.body,
+    document: document,
     className: (name: string) => true,
     tagName: (name: string) => true,
     seedMinLength: 1,
@@ -154,7 +156,7 @@ function penalty(path: Path): number {
 }
 
 function unique(path: Path) {
-  switch (document.querySelectorAll(selector(path)).length) {
+  switch (config.document.querySelectorAll(selector(path)).length) {
     case 0:
       throw new Error(`Can't select any node with this selector: ${selector(path)}`)
     case 1:
@@ -282,5 +284,5 @@ function* optimize(path: Path, input: Element) {
 }
 
 function same(path: Path, input: Element) {
-  return document.querySelector(selector(path)) === input
+  return config.document.querySelector(selector(path)) === input
 }


### PR DESCRIPTION
Towards: https://github.com/antonmedv/finder/issues/7

My use case here is that I have some code running in an embedded iframe, I want to grab a selector from `window.top.document`. Right now the code will always attempt to match against the iframe's document, this change allows us to specify the relevant doc.

LMK your thoughts on what the best way to test this would be.