### PR TITLE
Add default support for nodes inside iframes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Example of generated selector:
 
 ```js
 const selector = finder(event.target, {
-  root: document.body,
+  root: input.ownerDocument,
   className: (name) => true,
   tagName: (name) => true,
   attr: (name, value) => false,
@@ -67,7 +67,7 @@ const selector = finder(event.target, {
 
 #### `root: Element`
 
-Root of search, defaults to `document.body`.
+Root of search, defaults to `input.ownerDocument`.
 
 #### `idName: (name: string) => boolean`
 

--- a/finder.ts
+++ b/finder.ts
@@ -37,7 +37,7 @@ export function finder(input: Element, options?: Partial<Options>) {
   }
 
   const defaults: Options = {
-    root: document.body,
+    root: input.ownerDocument,
     idName: (name: string) => true,
     className: (name: string) => true,
     tagName: (name: string) => true,


### PR DESCRIPTION
This adds default support for computing CSS selectors for nodes inside iframes.

Node.ownerDocument is supported by IE 9 and up: https://developer.mozilla.org/en-US/docs/Web/API/Node/ownerDocument#Browser_compatibility