### PR TITLE
Mark package as an ES module

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@medv/finder",
   "version": "2.0.0",
   "description": "CSS Selector Generator",
+  "type": "module",
   "repository": "antonmedv/finder",
   "homepage": "https://github.com/antonmedv/finder",
   "author": "Anton Medvedev <anton@medv.io>",


### PR DESCRIPTION
This will allow tooling (like Next.js) to identify this package as an ES module and handle it accordingly