### PR TITLE
Add idName default to config section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Example of generated selector:
 ```js
 const selector = finder(event.target, {
   root: document.body,
+  idName: (name) => true,
   className: (name) => true,
   tagName: (name) => true,
   attr: (name, value) => false,


### PR DESCRIPTION
This PR adds the `idName` option's default value to the Configuration section of the README.