### PR TITLE
Omit tagName from nth-child selector as it is redundant

### DIFF
--- a/finder.ts
+++ b/finder.ts
@@ -264,7 +264,7 @@ function index(input: Element): number | null {
 
 function nthChild(node: Knot, i: number): Knot {
   return {
-    name: node.name + `:nth-child(${i})`,
+    name: `:nth-child(${i})`,
     penalty: node.penalty + 1,
   }
 }


### PR DESCRIPTION
This is another way of asking the following question which I asked in #3 

> I'm wondering why #some_id div:nth-child(2) a is preferred over #some_id :nth-child(2) a in the existing code? That div appears to be redundant in the examples I've checked.