### PR TITLE
Enable possibility of taking the tag name into account when deciding whether to use a class/id/attr.

### DIFF
--- a/finder.ts
+++ b/finder.ts
@@ -12,10 +12,10 @@ type Path = Knot[]
 
 export type Options = {
   root: Element
-  idName: (name: string) => boolean
-  className: (name: string) => boolean
+  idName: (name: string, tagName: string) => boolean
+  className: (name: string, tagName: string) => boolean
   tagName: (name: string) => boolean
-  attr: (name: string, value: string) => boolean
+  attr: (name: string, value: string, tagName: string) => boolean
   seedMinLength: number
   optimizedMinLength: number
   threshold: number
@@ -186,7 +186,7 @@ function unique(path: Path) {
 
 function id(input: Element): Knot | null {
   const elementId = input.getAttribute('id')
-  if (elementId && config.idName(elementId)) {
+  if (elementId && config.idName(elementId, input.tagName.toLowerCase())) {
     return {
       name: '#' + CSS.escape(elementId),
       penalty: 0,
@@ -197,7 +197,7 @@ function id(input: Element): Knot | null {
 
 function attr(input: Element): Knot[] {
   const attrs = Array.from(input.attributes).filter((attr) =>
-    config.attr(attr.name, attr.value)
+    config.attr(attr.name, attr.value, input.tagName.toLowerCase())
   )
   return attrs.map(
     (attr): Knot => ({
@@ -208,7 +208,9 @@ function attr(input: Element): Knot[] {
 }
 
 function classNames(input: Element): Knot[] {
-  const names = Array.from(input.classList).filter(config.className)
+  const names = Array.from(input.classList).filter((className) =>
+    config.className(className, input.tagName.toLowerCase())
+  )
   return names.map(
     (name): Knot => ({
       name: '.' + CSS.escape(name),


### PR DESCRIPTION
Main motivation is to only allow the `src` attribute to be used if it's on an image <IMG>, so I'd be happy if only `config.attr` was updated with this change, but included the others for completeness.

