### PR TITLE
Add Timeout to Finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ const selector = finder(event.target, {
   optimizedMinLength: 2,
   threshold: 1000,
   maxNumberOfTries: 10_000,
+  timeoutMs: undefined,
 })
 ```
 
@@ -76,6 +77,10 @@ selectors to check. Default `1000` is good enough in most cases.
 
 Max number of tries for the optimization. This is a trade-off between
 optimization and efficiency. Default `10_000` is good enough in most cases.
+
+### timeoutMs
+
+Optional timeout in milliseconds. `undefined` (no timeout) by default. If `timeoutMs: 500` is provided, an error will be thrown if selector generation takes more than 500ms.
 
 ## Become a sponsor
 

--- a/finder.ts
+++ b/finder.ts
@@ -20,6 +20,8 @@ export type Options = {
   optimizedMinLength: number
   threshold: number
   maxNumberOfTries: number
+  timeout: number
+  start: Date
 }
 
 let config: Options
@@ -42,6 +44,8 @@ export function finder(input: Element, options?: Partial<Options>) {
     optimizedMinLength: 2,
     threshold: 1000,
     maxNumberOfTries: 10000,
+    timeout: -1,
+    start: new Date(),
   }
 
   config = {...defaults, ...options}
@@ -84,6 +88,10 @@ function bottomUpSearch(
   let current: Element | null = input
   let i = 0
   while (current) {
+    const elapsedTime = new Date().getTime() - config.start.getTime();
+    if (config.timeout !== -1 && elapsedTime > config.timeout) {
+      throw new Error(`Timeout: Can't find a unique selector after ${elapsedTime}ms`)
+    }
     let level: Knot[] = maybe(id(current)) ||
       maybe(...attr(current)) ||
       maybe(...classNames(current)) ||

--- a/finder.ts
+++ b/finder.ts
@@ -20,14 +20,15 @@ export type Options = {
   optimizedMinLength: number
   threshold: number
   maxNumberOfTries: number
-  timeoutMs: number
-  start: Date
+  timeoutMs: number | undefined
 }
 
 let config: Options
 let rootDocument: Document | Element
+let start: Date
 
 export function finder(input: Element, options?: Partial<Options>) {
+  start = new Date()
   if (input.nodeType !== Node.ELEMENT_NODE) {
     throw new Error(`Can't generate CSS selector for non-element node type.`)
   }
@@ -44,8 +45,7 @@ export function finder(input: Element, options?: Partial<Options>) {
     optimizedMinLength: 2,
     threshold: 1000,
     maxNumberOfTries: 10000,
-    timeoutMs: -1,
-    start: new Date(),
+    timeoutMs: undefined,
   }
 
   config = {...defaults, ...options}
@@ -88,8 +88,8 @@ function bottomUpSearch(
   let current: Element | null = input
   let i = 0
   while (current) {
-    const elapsedTime = new Date().getTime() - config.start.getTime();
-    if (config.timeoutMs !== -1 && elapsedTime > config.timeoutMs) {
+    const elapsedTime = new Date().getTime() - start.getTime();
+    if (config.timeoutMs !== undefined && elapsedTime > config.timeoutMs) {
       throw new Error(`Timeout: Can't find a unique selector after ${elapsedTime}ms`)
     }
     let level: Knot[] = maybe(id(current)) ||

--- a/finder.ts
+++ b/finder.ts
@@ -20,7 +20,7 @@ export type Options = {
   optimizedMinLength: number
   threshold: number
   maxNumberOfTries: number
-  timeout: number
+  timeoutMs: number
   start: Date
 }
 
@@ -44,7 +44,7 @@ export function finder(input: Element, options?: Partial<Options>) {
     optimizedMinLength: 2,
     threshold: 1000,
     maxNumberOfTries: 10000,
-    timeout: -1,
+    timeoutMs: -1,
     start: new Date(),
   }
 
@@ -89,7 +89,7 @@ function bottomUpSearch(
   let i = 0
   while (current) {
     const elapsedTime = new Date().getTime() - config.start.getTime();
-    if (config.timeout !== -1 && elapsedTime > config.timeout) {
+    if (config.timeoutMs !== -1 && elapsedTime > config.timeoutMs) {
       throw new Error(`Timeout: Can't find a unique selector after ${elapsedTime}ms`)
     }
     let level: Knot[] = maybe(id(current)) ||


### PR DESCRIPTION
Addresses Issue #77 
Adding an optional timeout in milliseconds to finder for cases where finder calls need to execute under a certain time threshold.

I tested this by temporarily updating L14 of tests/test.js to `function check(html, config = {timeoutMs: 1}) {` and seeing that a few tests timed out:

<img width="720" alt="Screenshot 2024-02-20 at 6 14 18 PM" src="https://github.com/antonmedv/finder/assets/113386793/f2eecc45-b6d1-40ab-b067-0997a461d31b">
