### PR TITLE
build: only package typescript declaration files

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "finder.js",
   "types": "finder.d.ts",
   "files": [
-    "*.ts",
+    "*.d.ts",
     "*.js"
   ],
   "scripts": {


### PR DESCRIPTION
Fixes #76 

I ran into the same issue. I was using rollup and it didn't like having the typescript source in the package.