### PR TITLE
Check num combinations aginst threshold before generating paths

### DIFF
--- a/finder.ts
+++ b/finder.ts
@@ -147,10 +147,13 @@ function findUniquePath(
   stack: Knot[][],
   fallback?: () => Path | null
 ): Path | null {
-  const paths = sort(combinations(stack))
-  if (paths.length > config.threshold) {
-    return fallback ? fallback() : null
+  // Check first the total number of combinations first since generating the combinations can cause memory exhaustion
+  const numCombinations = stack.reduce((acc, i) => acc * i.length, 1);
+  if (numCombinations > config.threshold) {
+    return fallback ? fallback() : null;
   }
+  
+  const paths = sort(combinations(stack))
   for (let candidate of paths) {
     if (unique(candidate)) {
       return candidate


### PR DESCRIPTION
# Check Number of Combinations Against Threshold Before Generating Paths

## Summary
This pull request adds a safeguard against potential memory exhaustion in the `findUniquePath` function by checking the total number of possible combinations before generating them.

## Description
In the `findUniquePath` function, generating combinations of paths can lead to high memory usage if the number of combinations is large.

This update introduces a check that calculates the total number of combinations before proceeding to generate the combinations. If the number of combinations exceeds the configured threshold, the function will return a fallback path (if provided) or `null`.

## Changes Made
- Added a check to calculate the total number of combinations before generating paths.
- Modified the function to return early if the number of combinations exceeds the threshold, thus avoiding unnecessary computation and potential memory issues.
